### PR TITLE
Add configurable find ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ from a template path is the "app" directory (which is a common value for
 of these two things don't work for your use case, file a ticket, figure
 out why and file a pull request, or [use ctags][ctags].
 
+Results can be filtered by specifying exclusions in your .vimrc like this:
+
+```
+let g:angular_find_ignore = ['build', 'dist']
+```
+
 ### Run the current spec
 
 If you're writing jasmine unit tests for your angular app, they look like

--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -22,7 +22,15 @@ let g:syntastic_html_tidy_ignore_errors = g:syntastic_html_tidy_ignore_errors + 
   \ ]
 
 
-let g:FindIgnore = ['coverage/', 'test/', '.git']
+if !exists('g:angular_find_ignore')
+  let g:angular_find_ignore = []
+endif
+
+let g:angular_find_ignore = g:angular_find_ignore + [
+  \ 'coverage/',
+  \ 'test/',
+  \ '.git'
+  \ ]
 
 " Helper
 " Find file in or below current directory and edit it.
@@ -37,10 +45,10 @@ function! s:Find(...) abort
   endif
 
 
-  if !exists("g:FindIgnore")
+  if !exists("g:angular_find_ignore")
     let ignore = ""
   else
-    let ignore = " | egrep -v '".join(g:FindIgnore, "|")."'"
+    let ignore = " | egrep -v '".join(g:angular_find_ignore, "|")."'"
   endif
 
   let l:command="find ".path." -type f -iname '*".query."*'".ignore


### PR DESCRIPTION
Use case: ignore custom build/dist directories to filter `gf`'s results (and go
straight to the file if there's only one).

Since this variable has been exposed, it's customary to prefix with the plugin
name.
