### PR TITLE
Add angular-ui prefix to syntastic ignores

### DIFF
--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -17,7 +17,7 @@ endif
 
 let g:syntastic_html_tidy_ignore_errors = g:syntastic_html_tidy_ignore_errors + [
   \   ' proprietary attribute "ng-',
-  \   ' proprietary attribute "ui-view',
+  \   ' proprietary attribute "ui-',
   \   '<ng-include> is not recognized!',
   \   'discarding unexpected <ng-include>',
   \   'discarding unexpected </ng-include>',

--- a/spec/runspec_spec.rb
+++ b/spec/runspec_spec.rb
@@ -4,7 +4,7 @@ describe "runspec" do
 
   specify "html tidy syntastic ignores" do
     value_of_variable = vim.echo('g:syntastic_html_tidy_ignore_errors')
-    value_of_variable.should eq("[' proprietary attribute \"ng-', ' proprietary attribute \"ui-view', '<ng-include> is not recognized!', 'discarding unexpected <ng-include>', 'discarding unexpected </ng-include>', '<div> proprietary attribute \"src']")
+    value_of_variable.should eq("[' proprietary attribute \"ng-', ' proprietary attribute \"ui-', '<ng-include> is not recognized!', 'discarding unexpected <ng-include>', 'discarding unexpected </ng-include>', '<div> proprietary attribute \"src']")
   end
 
   specify "command with one spec" do


### PR DESCRIPTION
As AngularUI's suites are commonplace in Angular development, it's worth
relaxing the ignore rule to catch all ui-\* prefixed attributes (e.g. `ui-view`,
`ui-sref`, `ui-sref-active`, etc.).
