### PR TITLE
Make syntastic aware of <ng-form> directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Some niceties for using Vim with the AngularJS framework. See the [screencast][screencast].
 
 The [canonical "what editor should I use for Angular?" post][editorchoice]
-pretty squarely lands on Webstorm/IntelliJ as the peoples' choice 
+pretty squarely lands on Webstorm/IntelliJ as the peoples' choice
 (12 people), but Vim is right there tied for second place along with
 NetBeans and Sublime (four people each as of April, 2014) in this
 super-scientific analysis. And don't make me quote [Tim Pope][tpope] on
@@ -35,9 +35,9 @@ So why was this plugin written at all? I'm glad you asked!
 
 A, the "alternate" file, has been mapped to take you from your code to the
 corresponding test file, or from your test file to the corresponding
-implementation file. For example, if you're in app/js/rock-socks.js, and 
+implementation file. For example, if you're in app/js/rock-socks.js, and
 you hammer :A, you will be taken to test/spec/rock-socks.js, if such a file
-exists. Some other common directory structure conventions in the angular 
+exists. Some other common directory structure conventions in the angular
 community, such as app/src and test/unit, are also supported.
 
 If the convention you use doesn't work out of the box, you can specify your
@@ -69,7 +69,7 @@ if (true) {
 file called awesome-service.js somewhere in a subdirectory of your path,
 you will be taken there. The default behavior of gf can also be quite
 useful in the context of an angular app, since file paths appear in views
-(with ng-include src="full/path.html) and directives (with templateUrl: 
+(with ng-include src="full/path.html) and directives (with templateUrl:
 'src/myapp/modules/main/views//prompt-list.html', so an
 attempt has been made to allow this to work as well. If all that is missing
 from a template path is the "app" directory (which is a common value for
@@ -116,34 +116,45 @@ focus in on just one spec at a time (and one spec generally runs way fast).
 So, if you're anywhere inside a spec:
 
     :AngularRunSpec
-    
+
 or the "run spec" mapping:
 
     <leader>rs
-    
+
 will toggle the spec between "it" and "iit." This works especially well if
 you have a karma watch going, as shown in the [screencast][screencast].
 
 You are able to do the same with a describe block using the run block command:
-    
+
     :AngularRunSpecBlock
 
 or the corresponding mapping:
 
     <leader>rb
 
-### Syntastic syntax checker ignores
+### Syntastic syntax checker customization
 
 You know how you use syntastic to check your syntax as you edit, because
 it works for pretty much any language and is awesome? When you use angular
 directives (like ng-app, ng-repeat, and even library directives like
-ui-view), the html tidy check will complain. This is fixed out of the box,
-and you can use the same mechanism to make syntastic aware of your own
-directives by specifying exclusions in your .vimrc like this:
+ui-view), the html tidy check will complain. This is fixed out of the box.
+
+Use the same mechanism to make syntastic aware of your own directives by
+specifying exclusions in your .vimrc like this:
 
 ```
 let g:syntastic_html_tidy_ignore_errors = ['proprietary attribute "myhotcompany-']
 ```
+
+Some angular directives can also be used as custom elements (i.e. ng-include,
+ng-form). These are added to the list of allowed tags by default. In order
+to make syntastic recognize your additional blocklevel tags define them in your
+.vimrc before the plugin is loaded:
+
+```
+let g:syntastic_html_tidy_blocklevel_tags = ['myCustomTag']
+```
+
 
 ## Installation
 

--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -7,10 +7,11 @@
 "
 " define your own proprietary attributes before this plugin loads, in your
 " .vimrc, like so:
-" let g:syntastic_html_tidy_ignore_errors = [' proprietary attribute "myhotcompany-']
+" let g:syntastic_html_tidy_ignore_errors   = [' proprietary attribute "myhotcompany-']
+" let g:syntastic_html_tidy_blocklevel_tags = ['myCustomTag']
 "
-" or copy the mechanism used here to ensure you get both your ignores and
-" the plugin's ignores.
+" or copy the mechanism used here to ensure you get both your settings and
+" the ones defined by the plugin.
 if !exists('g:syntastic_html_tidy_ignore_errors')
   let g:syntastic_html_tidy_ignore_errors = []
 endif
@@ -18,12 +19,17 @@ endif
 let g:syntastic_html_tidy_ignore_errors = g:syntastic_html_tidy_ignore_errors + [
   \   ' proprietary attribute "ng-',
   \   ' proprietary attribute "ui-',
-  \   '<ng-include> is not recognized!',
-  \   'discarding unexpected <ng-include>',
-  \   'discarding unexpected </ng-include>',
   \   '<div> proprietary attribute "src'
   \ ]
 
+if !exists('g:syntastic_html_tidy_blocklevel_tags')
+  let g:syntastic_html_tidy_blocklevel_tags = []
+endif
+
+let g:syntastic_html_tidy_blocklevel_tags = g:syntastic_html_tidy_blocklevel_tags + [
+  \ 'ng-include',
+  \ 'ng-form'
+  \ ]
 
 if !exists('g:angular_find_ignore')
   let g:angular_find_ignore = []

--- a/spec/runspec_spec.rb
+++ b/spec/runspec_spec.rb
@@ -4,7 +4,19 @@ describe "runspec" do
 
   specify "html tidy syntastic ignores" do
     value_of_variable = vim.echo('g:syntastic_html_tidy_ignore_errors')
-    value_of_variable.should eq("[' proprietary attribute \"ng-', ' proprietary attribute \"ui-', '<ng-include> is not recognized!', 'discarding unexpected <ng-include>', 'discarding unexpected </ng-include>', '<div> proprietary attribute \"src']")
+    value_of_variable.should include(
+      ' proprietary attribute "ng-',
+      ' proprietary attribute "ui-',
+      '<div> proprietary attribute "src'
+    )
+  end
+
+  specify "html tidy syntastic tags" do
+    value_of_variable = vim.echo('g:syntastic_html_tidy_blocklevel_tags')
+    value_of_variable.should include(
+      'ng-include',
+      'ng-form'
+    )
   end
 
   specify "command with one spec" do


### PR DESCRIPTION
I have added <ng-form> to the list of recognized block level tags for the syntastic html checker. Also refactored the ignores for <ng-include> to leverage the same setting. Updated comment an documentation.