### PR TITLE
Generally do not warn on empty tags

### DIFF
--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -21,7 +21,7 @@ let g:syntastic_html_tidy_ignore_errors += [
   \   ' proprietary attribute "ui-',
   \   ' proprietary attribute "src"',
   \   ' proprietary attribute "on"',
-  \   'trimming empty <select>'
+  \   'trimming empty <'
   \ ]
 
 if !exists('g:syntastic_html_tidy_blocklevel_tags')

--- a/spec/runspec_spec.rb
+++ b/spec/runspec_spec.rb
@@ -9,7 +9,7 @@ describe "runspec" do
       ' proprietary attribute "ui-',
       ' proprietary attribute "src"',
       ' proprietary attribute "on"',
-      'trimming empty <select>'
+      'trimming empty <'
     )
   end
 


### PR DESCRIPTION
Because of `ng-bind` and friends any content tag can be empty. So I disabled all warnings on empty tags in general.