### PR TITLE
Do not warn on proprietary attributes

### DIFF
--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -17,10 +17,7 @@ if !exists('g:syntastic_html_tidy_ignore_errors')
 endif
 
 let g:syntastic_html_tidy_ignore_errors += [
-  \   ' proprietary attribute "ng-',
-  \   ' proprietary attribute "ui-',
-  \   ' proprietary attribute "src"',
-  \   ' proprietary attribute "on"',
+  \   '> proprietary attribute "',
   \   'trimming empty <'
   \ ]
 

--- a/spec/runspec_spec.rb
+++ b/spec/runspec_spec.rb
@@ -5,10 +5,7 @@ describe "runspec" do
   specify "html tidy syntastic ignores" do
     value_of_variable = vim.echo('g:syntastic_html_tidy_ignore_errors')
     value_of_variable.should include(
-      ' proprietary attribute "ng-',
-      ' proprietary attribute "ui-',
-      ' proprietary attribute "src"',
-      ' proprietary attribute "on"',
+      '> proprietary attribute "',
       'trimming empty <'
     )
   end


### PR DESCRIPTION
As custom attribute style directives can have any name generally do not warn on proprietary attributes.