### PR TITLE
Include check for dashcase . <ng type> .js [#18]

### DIFF
--- a/plugin/angular.vim
+++ b/plugin/angular.vim
@@ -151,6 +151,7 @@ function! s:FindFileBasedOnAngularServiceUnderCursor(cmd) abort
   for query in l:queries
     try
       call <SID>Find(query, a:cmd)
+      break
     catch 'AngularQueryNotFound'
       if (query == l:filethatmayexistngdotcase)
         echo "angular.vim says: '".join(l:queries, ', ')."' not found"


### PR DESCRIPTION
This change adds support for files named according to common conventions such as:
- The [Angular team endorsed style guide by John Papa](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#feature-file-names)
- [Todd Motto's Angular Style Guide](https://github.com/toddmotto/angular-styleguide#scalable-file-structure)

The existing filename patterns are tried first, then the style from the above style guides, referred to in the changes as `dashcasewithngtype`.

Here's an excerpt from the second one to illustrate the naming style:

```
├── app/
│   ├── components/
│   │  ├── calendar/
│   │  │  ├── index.js
│   │  │  ├── calendar.controller.js
│   │  │  ├── calendar.component.js
│   │  │  ├── calendar.service.js
│   │  │  ├── calendar.spec.js
│   │  │  └── calendar-grid/
│   │  │     ├── index.js
│   │  │     ├── calendar-grid.controller.js
│   │  │     ├── calendar-grid.component.js
│   │  │     ├── calendar-grid.directive.js
│   │  │     ├── calendar-grid.filter.js
│   │  │     └── calendar-grid.spec.js
│   │  └── events/
│   │     ├── index.js
│   │     ├── events.controller.js
│   │     ├── events.component.js
│   │     ├── events.directive.js
│   │     ├── events.service.js
│   │     ├── events.spec.js
│   │     └── events-signup/
│   │        ├── index.js
│   │        ├── events-signup.controller.js
│   │        ├── events-signup.component.js
│   │        ├── events-signup.service.js
│   │        └── events-signup.spec.js
│   ├── common/
│   │  ├── nav/
│   │  │     ├── index.js
│   │  │     ├── nav.controller.js
│   │  │     ├── nav.component.js
│   │  │     ├── nav.service.js
│   │  │     └── nav.spec.js
│   │  └── footer/
│   │        ├── index.js
│   │        ├── footer.controller.js
│   │        ├── footer.component.js
│   │        ├── footer.service.js
│   │        └── footer.spec.js
│   ├── app.js
│   └── app.component.js
└── index.html
```
